### PR TITLE
Fix AQI Calculation

### DIFF
--- a/aqi.py
+++ b/aqi.py
@@ -40,7 +40,7 @@ class AQI:
     @classmethod
     def _calculate_aqi(cls, breakpoints, data):
         for index, data_range in enumerate(breakpoints):
-            if data <= data_range[0]:
+            if data <= data_range[1]:
                 break
 
         i_low, i_high = cls.AQI[index]


### PR DESCRIPTION
Currently calculation breaks when the data point is less than or equal to the LOW value of the current data_range. It should be less than or equal to the high value of the current data_range, in order to select the correct data_range. Its very wrong at low concentrations.

A PM 2.5 concentration of 0.1 gives an AQI of 26+ when it should be 1, according to the EPA calculator. This change fixes it.

Fixes #4